### PR TITLE
Return nil if the query fails

### DIFF
--- a/lib/puppet/provider/package/apk.rb
+++ b/lib/puppet/provider/package/apk.rb
@@ -38,6 +38,7 @@ Puppet::Type.type(:package).provide :apk, :parent => ::Puppet::Provider::Package
     self.class.instances.each do |provider|
       return provider.properties if name.downcase == provider.name.downcase
     end
+    return nil
   end
 
   def latest

--- a/lib/puppet/provider/package/apk.rb
+++ b/lib/puppet/provider/package/apk.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:package).provide :apk, :parent => ::Puppet::Provider::Package
     self.class.instances.each do |provider|
       return provider.properties if name.downcase == provider.name.downcase
     end
-    return nil
+    return
   end
 
   def latest


### PR DESCRIPTION
If query has nothing to return explicitly return nil (otherwise `self.class.instances` is returned)
