### PR TITLE
Fix 'Could not evaluate: no implicit conversion of Symbol into Integer'

### DIFF
--- a/lib/puppet/provider/package/apk.rb
+++ b/lib/puppet/provider/package/apk.rb
@@ -42,6 +42,10 @@ Puppet::Type.type(:package).provide :apk, :parent => ::Puppet::Provider::Package
     self.class.instances.each do |provider|
       return provider.properties if name.downcase == provider.name.downcase
     end
+    # Explicit return because if no match is made/returned, then .each returns
+    # the self.class.instances array. This results in puppet thorwing a 
+    # 'Could not evaluate: no implicit conversion of Symbol into Integer' error.
+    return
   end
 
   def latest


### PR DESCRIPTION
Using this library, I encounter the following issues running on alpine linux 3.4.

```
Debug: Prefetching apk resources for package
Debug: Executing: '/sbin/apk info'
Debug: Executing: '/sbin/apk info -v'
Debug: Executing: '/sbin/apk info'
Debug: Executing: '/sbin/apk info -v'
Error: /Package[squid]: Could not evaluate: no implicit conversion of Symbol into Integer
Debug: Class[Squid::Install]: Resource is being skipped, unscheduling all events
Debug: Class[Squid::Config]: Resource is being skipped, unscheduling all events
```

Adding an explict nil return fixes this issue.
